### PR TITLE
Fix : ウインドウの大きさを変えた時にUIのサイズが変わってしまうのを修正

### DIFF
--- a/src/NePPUIPackage/NePPBookContents/NePPBookContentsUI.module.css
+++ b/src/NePPUIPackage/NePPBookContents/NePPBookContentsUI.module.css
@@ -7,13 +7,13 @@
     border: 1px solid #ddd;
     border-radius: 8px;
     position: relative;
-    gap: 20px
-    width calc((100% - 32px) / 3)
+    gap: 20px;
+    height : 120px;
 }
 
 .bookImageWrapper {
     position: relative;
-    width: 100%;
+    width: 100px;
     aspect-ratio: 1 / 1;
     margin-bottom: 0px;
 }

--- a/src/NePPUIPackage/NePPBookContents/NePPBookContentsUI.module.css
+++ b/src/NePPUIPackage/NePPBookContents/NePPBookContentsUI.module.css
@@ -30,7 +30,7 @@
     font-size: 20px;
     font-weight: bold;
     text-align: left;
-    width: 100%;
+    width: 120px;
 }
 
 


### PR DESCRIPTION
NePPBookContentsUIのCSSを修正しました
・ウインドウの大きさを変えても画像のサイズ、テキストの大きさが保持されるようにしました