### PR TITLE
NePPBookContentsUIをクリックした時に処理を実行できるように変更

### DIFF
--- a/src/NePPUIPackage/NePPBookContents/MainImage.tsx
+++ b/src/NePPUIPackage/NePPBookContents/MainImage.tsx
@@ -3,8 +3,9 @@ import styles from './NePPBookContentsUI.module.css';
 type MainImageProps = {
     src: string;
     alt?: string;
+    onImageClick?: () => void;
 };
 
-export function MainImage({ src, alt = '' }: MainImageProps) {
-    return <img className={styles.bookImage} src={src} alt={alt} />;
+export function MainImage({ src, alt = '', onImageClick}: MainImageProps) {
+    return <img className={styles.bookImage} src={src} alt={alt} onClick={onImageClick}/>;
 }

--- a/src/NePPUIPackage/NePPBookContents/MainText.tsx
+++ b/src/NePPUIPackage/NePPBookContents/MainText.tsx
@@ -2,8 +2,9 @@ import styles from './NePPBookContentsUI.module.css';
 
 type MainTextProps = {
     text: string;
+    onTextClick? : () => void;
 };
 
-export function MainText({ text }: MainTextProps) {
-    return <div className={styles.bookTitle}>{text}</div>;
+export function MainText({ text, onTextClick}: MainTextProps) {
+    return <div className={styles.bookTitle} onClick={onTextClick}>{text}</div>;
 }

--- a/src/NePPUIPackage/NePPBookContents/NePPBookContentsUI.module.css
+++ b/src/NePPUIPackage/NePPBookContents/NePPBookContentsUI.module.css
@@ -15,7 +15,7 @@
     position: relative;
     width: 100px;
     aspect-ratio: 1 / 1;
-    margin-bottom: 0px;
+    margin-bottom: 1px;
 }
 
 .bookImage {
@@ -24,6 +24,13 @@
     object-fit: cover;
     border-radius: 4px;
     display: block;
+    cursor: pointer;
+    transition: transform 0.25s ease-out;
+    transform-origin: center;
+}
+
+.bookImage:hover{
+    transform: scale(1.1);   
 }
 
 .bookTitle {
@@ -52,4 +59,8 @@
     left: 55%;
     width: 80px;
     height: auto;
+}
+
+@media (prefers-reduced-motion: reduce){
+    
 }

--- a/src/NePPUIPackage/NePPBookContents/NePPBookContentsUI.module.css
+++ b/src/NePPUIPackage/NePPBookContents/NePPBookContentsUI.module.css
@@ -4,7 +4,7 @@
     align-items: center;
     background: #ffffff;
     padding: 16px;
-    border: 1px solid #ddd;
+    
     border-radius: 8px;
     position: relative;
     gap: 20px;
@@ -25,12 +25,12 @@
     border-radius: 4px;
     display: block;
     cursor: pointer;
-    transition: transform 0.25s ease-out;
+    transition: transform 1s cubic-bezier(.18,1.87,.38,.89);
     transform-origin: center;
 }
 
 .bookImage:hover{
-    transform: scale(1.1);   
+    transform: scale(1.2);   
 }
 
 .bookTitle {

--- a/src/NePPUIPackage/NePPBookContents/NePPBookContentsUI.module.css
+++ b/src/NePPUIPackage/NePPBookContents/NePPBookContentsUI.module.css
@@ -31,6 +31,11 @@
     font-weight: bold;
     text-align: left;
     width: 120px;
+    cursor: pointer;
+}
+
+.bookTitle:hover {
+    text-decoration: underline;
 }
 
 

--- a/src/NePPUIPackage/NePPBookContents/NePPBookContentsUI.tsx
+++ b/src/NePPUIPackage/NePPBookContents/NePPBookContentsUI.tsx
@@ -13,7 +13,7 @@ type NePPBookContentsUIProps = {
 };
 
 function testFunc(){
-    console.log("MainText がクリックされました（デフォルト処理）");
+    console.log("NePPBookContentsUIがクリックされました（デフォルト処理）");
 }
 
 export function NePPBookContentsUI({ imageSrc, 
@@ -27,7 +27,7 @@ export function NePPBookContentsUI({ imageSrc,
         <>
             <div className={styles.container}>
                 <div className={styles.bookImageWrapper}>
-                    <MainImage src={imageSrc} alt="Book Cover" />
+                    <MainImage src={imageSrc} alt="Book Cover" onImageClick={onCardClick}/>
                     <StatusText isAvailable={isAvailable} />
                 </div>
             </div>

--- a/src/NePPUIPackage/NePPBookContents/NePPBookContentsUI.tsx
+++ b/src/NePPUIPackage/NePPBookContents/NePPBookContentsUI.tsx
@@ -9,9 +9,20 @@ type NePPBookContentsUIProps = {
     title: string;
     description: string;
     isAvailable: boolean; 
+    onCardClick? : () => void;
 };
 
-export function NePPBookContentsUI({ imageSrc, title, description, isAvailable }: NePPBookContentsUIProps) {
+function testFunc(){
+    console.log("MainText がクリックされました（デフォルト処理）");
+}
+
+export function NePPBookContentsUI({ imageSrc, 
+                                       title, 
+                                       description, 
+                                       isAvailable, 
+                                       onCardClick = testFunc}: 
+                                   NePPBookContentsUIProps) 
+{
     return (
         <>
             <div className={styles.container}>
@@ -20,7 +31,7 @@ export function NePPBookContentsUI({ imageSrc, title, description, isAvailable }
                     <StatusText isAvailable={isAvailable} />
                 </div>
             </div>
-            <MainText text={title} />
+            <MainText text={title} onTextClick={onCardClick} />
             <SubText text={description} />
         </>
     );


### PR DESCRIPTION
NePPBookContentsUIに変更を入れました
・MainText、MainImageをクリックした時の関数を設定できるようにしました

<NePPUI.NePPBookContentsUI
          key={book.id} 
          title={book.title}
          imageSrc={book.cover_image_url} 
          description={book.description}
          isAvailable={book.isAvailable} 
` onCardClick={() => console.log('clicked')}`
        />

上記のようにonCardClickに処理を渡すとクリック時の処理を追加できます👍

・テキストにカーソルを合わせた時に下線を表示するようにしました
・画像にカーソルを合わせた時に画像が少し大きくなるようにしました
・画像の周りを囲んでいた線を削除しました